### PR TITLE
Simplify the Makefile a bit by using in-file constants for tile dimensions

### DIFF
--- a/add/host.c
+++ b/add/host.c
@@ -5,6 +5,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+const size_t TILES_X = 4;
+const size_t TILES_Y = 4;
+
 int do_add(int32_t src1, int32_t src2, int32_t *dest) {
     int err;
 
@@ -50,7 +53,7 @@ int do_add(int32_t src1, int32_t src2, int32_t *dest) {
     // arguments to `hb_mc_application_init` specify the arguments to the `add`
     // function in the device code.
     hb_mc_dimension_t grid_dim = {.x = 1, .y = 1};
-    hb_mc_dimension_t tg_dim = {.x = bsg_tiles_X, .y = bsg_tiles_Y};
+    hb_mc_dimension_t tg_dim = {.x = TILES_X, .y = TILES_Y};
     err = hb_mc_application_init(&device, grid_dim, tg_dim, "add", 3, args);
     if (err) return err;
 

--- a/hb.mk
+++ b/hb.mk
@@ -27,7 +27,7 @@ bsg_group_size := 1
 # Build host code with the "normal" compiler.
 
 HOST_OBJS := $(HOST_SRCS:.c=.o)
-HOST_CFLAGS := -std=c11 -lbsg_manycore_runtime -Dbsg_tiles_X=$(bsg_tiles_X) -Dbsg_tiles_Y=$(bsg_tiles_Y)
+HOST_CFLAGS := -std=c11 -lbsg_manycore_runtime
 HOST_CC := cc
 
 $(HOST_TARGET): $(HOST_OBJS)
@@ -53,7 +53,7 @@ DEVICE_OBJS := $(DEVICE_SRCS:.c=.o)
 DEVICE_OBJS_ALL := $(DEVICE_OBJS) $(BSG_MANYCORE_LIB_OBJS)
 
 $(DEVICE_TARGET): $(DEVICE_OBJS_ALL) $(DEVICE_NON_C_OBJS)
-	$(RISCV_LINK) $^ -o $@ $(RISCV_LINK_OPTS) 
+	$(RISCV_LINK) $^ -o $@ $(RISCV_LINK_OPTS)
 
 $(DEVICE_OBJS_ALL): %.o: %.c
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) $(spmd_defs) -c $< -o $@

--- a/hb.mk
+++ b/hb.mk
@@ -15,14 +15,6 @@ all: $(DEVICE_TARGET) $(HOST_TARGET)
 clean:
 	rm -rf $(HOST_OBJS) $(DEVICE_OBJS_ALL) $(HOST_TARGET) $(DEVICE_TARGET)
 
-# Declare dimensions of the hammerblade
-
-bsg_tiles_X := 4
-bsg_tiles_Y := 4
-
-# doesn't seem to do anything but needs to be defined
-#
-bsg_group_size := 1
 
 # Build host code with the "normal" compiler.
 
@@ -38,6 +30,13 @@ $(HOST_OBJS): %.o: %.c
 
 
 # Include bsg_manycore Make infrastructure.
+
+# The dimensions of the tiles we'll run on.
+bsg_tiles_X := 4
+bsg_tiles_Y := 4
+
+# Doesn't seem to do anything, but needs to be defined.
+bsg_group_size := 1
 
 BSG_MANYCORE_DIR := $(wildcard /home/centos/bsg_bladerunner/bsg_manycore_*)
 BSG_F1_DIR := $(wildcard /home/centos/bsg_bladerunner/bsg_f1_*)

--- a/inter-tile-communication/host.c
+++ b/inter-tile-communication/host.c
@@ -5,6 +5,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+const size_t TILES_X = 4;
+const size_t TILES_Y = 4;
+
 int do_communication(int32_t src1, int32_t *dest) {
     int err;
 
@@ -47,7 +50,7 @@ int do_communication(int32_t src1, int32_t *dest) {
     // arguments to `hb_mc_application_init` specify the arguments to the `communicate`
     // function in the device code.
     hb_mc_dimension_t grid_dim = {.x = 1, .y = 1};
-    hb_mc_dimension_t tg_dim = {.x = bsg_tiles_X, .y = bsg_tiles_Y};
+    hb_mc_dimension_t tg_dim = {.x = TILES_X, .y = TILES_Y};
     err = hb_mc_application_init(&device, grid_dim, tg_dim, "communicate", 2, args);
     if (err) return err;
 

--- a/llvm-fibonacci/Makefile
+++ b/llvm-fibonacci/Makefile
@@ -6,8 +6,8 @@ DEVICE_TARGET := fib.riscv
 
 CLANG := 1
 
-# Build the LLVM IR 
-%.s: %.ll 
+# Build the LLVM IR
+%.s: %.ll
 	$(LLVM_CLANG) $(RISCV_GCC_OPTS) $(spmd_defs) -fno-addrsig $(INCS) $< -S -o $@
 
 %.o: %.s

--- a/llvm-fibonacci/host.c
+++ b/llvm-fibonacci/host.c
@@ -10,6 +10,9 @@
 
 #include "../shared/bsg-host-communication.h"
 
+const size_t TILES_X = 4;
+const size_t TILES_Y = 4;
+
 int do_fib(int32_t *dest) {
     int err;
 
@@ -23,14 +26,14 @@ int do_fib(int32_t *dest) {
     if (err) return err;
 
     hb_mc_dimension_t grid_dim = {.x = 1, .y = 1};
-    hb_mc_dimension_t tg_dim = {.x = bsg_tiles_X, .y = bsg_tiles_Y};
+    hb_mc_dimension_t tg_dim = {.x = TILES_X, .y = TILES_X};
     err = hb_mc_application_init(&device, grid_dim, tg_dim, "fib", 0, NULL);
     if (err) return err;
 
     // Run the function.
     err = hb_mc_device_tile_groups_execute(&device);
     if (err) return err;
-    
+
     // Get the return value, which should be a single int sum
     receive_return(dest, sizeof(int), &device);
 

--- a/message-communication/host.c
+++ b/message-communication/host.c
@@ -9,6 +9,9 @@
 
 #include "../shared/bsg-host-communication.h"
 
+const size_t TILES_X = 4;
+const size_t TILES_Y = 4;
+
 int do_communication(int32_t *dest) {
     int err;
 
@@ -25,7 +28,7 @@ int do_communication(int32_t *dest) {
     // arguments to `hb_mc_application_init` specify the arguments to the `communicate`
     // function in the device code.
     hb_mc_dimension_t grid_dim = {.x = 1, .y = 1};
-    hb_mc_dimension_t tg_dim = {.x = bsg_tiles_X, .y = bsg_tiles_Y};
+    hb_mc_dimension_t tg_dim = {.x = TILES_X, .y = TILES_Y};
     err = hb_mc_application_init(&device, grid_dim, tg_dim, "communicate", 0, NULL);
     if (err) return err;
 

--- a/noop/host.c
+++ b/noop/host.c
@@ -6,6 +6,10 @@
 #include <bsg_manycore_cuda.h>
 #include <stdio.h>
 
+// The dimensions of the tile group we'll use on the manycore.
+const size_t TILES_X = 4;
+const size_t TILES_Y = 4;
+
 int main(int argc, const char **argv) {
     int err;
 
@@ -28,13 +32,14 @@ int main(int argc, const char **argv) {
     // Set up the "tile groups" and "grid." We also specify the function
     // name and set the arguments (`argc` and `argv`) for the function we'll
     // eventually call.
-    // The dimensions of the tile group are set to 4x4 here, which matches
-    // some build-time parameters set in our Makefile.
-    // `grid_dim` seems to control the _number_ of 2x2 tile
-    // groups---it seems like this should _always_ be 1x1 (I'm not sure why
-    // you would want anything else).
+    // The dimensions of the tile group are set to `TILES_X`x`TILES_Y` here,
+    // which might need to match some build-time parameters in the device
+    // code, set in our Makefile.
+    // `grid_dim` seems to control the _number_ of tile groups of that
+    // size---it seems like this should _always_ be 1x1 (I'm not sure why you
+    // would want anything else).
     hb_mc_dimension_t grid_dim = {.x = 1, .y = 1};
-    hb_mc_dimension_t tg_dim = {.x = bsg_tiles_X, .y = bsg_tiles_Y};
+    hb_mc_dimension_t tg_dim = {.x = TILES_X, .y = TILES_Y};
     err = hb_mc_application_init(&device, grid_dim, tg_dim, "noop", 0, NULL);
     if (err) {
         fprintf(stderr, "error in hb_mc_application_init\n");

--- a/report/host.c
+++ b/report/host.c
@@ -5,6 +5,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define TILES_X 4
+#define TILES_Y 4
+
 int do_report(int32_t *outvals, size_t size) {
     int err;
 
@@ -24,7 +27,7 @@ int do_report(int32_t *outvals, size_t size) {
 
     // Set up the grid, group, and function. There's only one argument.
     hb_mc_dimension_t grid_dim = {.x = 1, .y = 1};
-    hb_mc_dimension_t tg_dim = {.x = bsg_tiles_X, .y = bsg_tiles_Y};
+    hb_mc_dimension_t tg_dim = {.x = TILES_X, .y = TILES_X};
     err = hb_mc_application_init(&device, grid_dim, tg_dim, "report", 1, &out_addr);
     if (err) return err;
 
@@ -42,7 +45,7 @@ int do_report(int32_t *outvals, size_t size) {
     if (err) return err;
 }
 
-const int TILE_COUNT = bsg_tiles_X * bsg_tiles_Y;  // Our group of tiles.
+const int TILE_COUNT = TILES_X * TILES_X;  // Our group of tiles.
 const int VALUE_COUNT = 9;  // Each tile reports 9 things.
 const char *VALUE_NAMES[] = {
     "__bsg_x",

--- a/sram-read-write/host.c
+++ b/sram-read-write/host.c
@@ -6,7 +6,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-const int TILE_COUNT = bsg_tiles_X * bsg_tiles_Y;  // Our group of tiles.
+#define TILES_X 4
+#define TILES_Y 4
+const int TILE_COUNT = TILES_X * TILES_Y;  // Our group of tiles.
 
 int do_sram_read_write(int32_t *dest) {
     int err;
@@ -23,36 +25,36 @@ int do_sram_read_write(int32_t *dest) {
     // Look up the global value by symbol name in the device SRAM. "EVA" is for
     // "endpoint virtual address," and it represents an address in the device's
     // memory.
-    hb_mc_eva_t global_value_eva; 
+    hb_mc_eva_t global_value_eva;
     err = hb_mc_loader_symbol_to_eva(device.program->bin, device.program->bin_size,
-        "global_value", &global_value_eva); 
-    if (err != HB_MC_SUCCESS) { 
+        "global_value", &global_value_eva);
+    if (err != HB_MC_SUCCESS) {
         fprintf(stderr, "hb_mc_loader_symbol_to_eva failed\n");
         return err;
     }
 
     // Set up the tile group, dimensions, and function to call. The last two
-    // arguments to `hb_mc_application_init` specify the (empty) arguments to 
+    // arguments to `hb_mc_application_init` specify the (empty) arguments to
     // sram_read_write
     hb_mc_dimension_t grid_dim = {.x = 1, .y = 1};
-    hb_mc_dimension_t tg_dim = {.x = bsg_tiles_X, .y = bsg_tiles_Y};
+    hb_mc_dimension_t tg_dim = {.x = TILES_X, .y = TILES_Y};
     err = hb_mc_application_init(&device, grid_dim, tg_dim, "local_sram_read_write", 0, NULL);
     if (err) return err;
 
     for (int32_t i = 0; i < TILE_COUNT; i++) {
-        // Get the tile coordinate for each tile. Note that because the first row 
+        // Get the tile coordinate for each tile. Note that because the first row
         // is reserved for I/O, tile ID 0 corresponds to coordinate (0, 1) and
         // so on. We use the tile coordinates because we want to write different
         // values per tile.
         hb_mc_coordinate_t tile_coordinate = device.mesh->tiles[i].coord;
 
         // Write a _different_ value per tile (in this case, the tile ID)
-        err =  hb_mc_manycore_eva_write(device.mc, &default_map, &tile_coordinate, 
+        err =  hb_mc_manycore_eva_write(device.mc, &default_map, &tile_coordinate,
             &global_value_eva, &i, sizeof(int32_t));
-        if (err != HB_MC_SUCCESS) { 
+        if (err != HB_MC_SUCCESS) {
             fprintf(stderr, "hb_mc_manycore_eva_write failed\n");
             return err;
-        }  
+        }
     }
 
     // Run the function.
@@ -60,10 +62,10 @@ int do_sram_read_write(int32_t *dest) {
     if (err) return err;
 
     // Lookup the return EVA
-    hb_mc_eva_t global_return_eva; 
+    hb_mc_eva_t global_return_eva;
     err = hb_mc_loader_symbol_to_eva(device.program->bin, device.program->bin_size,
-        "global_return", &global_return_eva); 
-    if (err != HB_MC_SUCCESS) { 
+        "global_return", &global_return_eva);
+    if (err != HB_MC_SUCCESS) {
         fprintf(stderr, "hb_mc_loader_symbol_to_eva failed\n");
         return err;
     }
@@ -72,7 +74,7 @@ int do_sram_read_write(int32_t *dest) {
     for (int32_t i = 0; i < TILE_COUNT; i++) {
         hb_mc_coordinate_t tile_coordinate = device.mesh->tiles[i].coord;
         err = hb_mc_manycore_eva_read(device.mc, &default_map, &tile_coordinate,
-            &global_return_eva, &(dest[i]), sizeof(int32_t)); 
+            &global_return_eva, &(dest[i]), sizeof(int32_t));
         if (err) {
             fprintf(stderr, "hb_mc_device_memcpy to host failed\n");
             return err;


### PR DESCRIPTION
I've now defined `TILES_X` and `TILES_Y` constants within each example instead of providing these with `-D` flags in the Makefile. I know this is more repetitive, but for documentation purposes, it emphasizes that the host code doesn't actually need these macros—the size of the tile group that the host code uses is a run-time decision, and it doesn't need to be baked in.

I also wanted to emphasize that we are not required to use this precise constant name, unlike in the device code, where this is a "magical" constant used in the `bsg_manycore` header files.